### PR TITLE
Fix/exterior wall painting layout：サービスページ・サービス詳細ページの修正

### DIFF
--- a/nextjs-team-practice/app/components/latest-works.tsx
+++ b/nextjs-team-practice/app/components/latest-works.tsx
@@ -41,7 +41,7 @@ export function LatestWorks() {
                   <p className="text-sm mb-4">{work.description}</p>
                   <Button 
                     variant="outline" 
-                    className="w-full border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
+                    className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
                   >
                     詳細を見る→
                   </Button>

--- a/nextjs-team-practice/app/components/services.tsx
+++ b/nextjs-team-practice/app/components/services.tsx
@@ -29,7 +29,7 @@ export function Services() {
                 <p className="text-sm mb-4">{service.description}</p>
                 <Button 
                   variant="outline" 
-                  className="w-full border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
+                  className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
                 >
                   詳細を見る→
                 </Button>

--- a/nextjs-team-practice/app/components/shared/footer.tsx
+++ b/nextjs-team-practice/app/components/shared/footer.tsx
@@ -24,7 +24,7 @@ const footerLinks = {
 
 export function Footer() {
   return (
-    <footer className="bg-white py-12 border-t">
+    <footer className="bg-[#F3F3F3] py-12 border-t">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-6 gap-8">
           <div className="md:col-span-2">

--- a/nextjs-team-practice/app/globals.css
+++ b/nextjs-team-practice/app/globals.css
@@ -11,10 +11,10 @@
 .step-container::before {
   content: '';
   position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
+  top: -15px;
+  left: -15px;
+  right: -15px;
+  bottom: -15px;
   background: #005a64;
   clip-path: polygon(0% 0%, 85% 0%, 100% 50%, 85% 100%, 0% 100%);
 }

--- a/nextjs-team-practice/app/services/[type]/page.tsx
+++ b/nextjs-team-practice/app/services/[type]/page.tsx
@@ -41,6 +41,7 @@ export default async function ServiceDetailPage({
       <Header />
       <ServiceDetailHero title={serviceTitle} />
       <main>
+       <div className="container mx-auto px-4">
           <Breadcrumb 
             items={[
               { label: 'ホーム', href: '/' },
@@ -70,9 +71,11 @@ export default async function ServiceDetailPage({
             </div>
           </section>
 
-        <FAQSection />
-      </main>
+          <FAQSection />
+          
+      </div>
       <ContactCTA />
+      </main>
       <Footer />
     </div>
   )

--- a/nextjs-team-practice/app/services/[type]/page.tsx
+++ b/nextjs-team-practice/app/services/[type]/page.tsx
@@ -36,18 +36,11 @@ export default async function ServiceDetailPage({
     resolvedParams.type === 'special-painting' ? '特殊塗装' :
     '塗装サービス';
 
-  const serviceDescription = 
-    resolvedParams.type === 'exterior-wall-painting' ? 'お客様のニーズに合わせた高品質な外壁塗装サービスを提供いたします。' :
-    resolvedParams.type === 'roof-painting' ? 'お客様のニーズに合わせた高品質な屋根塗装サービスを提供いたします。' :
-    resolvedParams.type === 'special-painting' ? 'お客様のニーズに合わせた高品質な特殊塗装サービスを提供いたします。' :
-    'お客様のニーズに合わせた高品質な塗装サービスを提供いたします。';
-
   return (
     <div className="min-h-screen">
       <Header />
       <ServiceDetailHero title={serviceTitle} />
       <main>
-        <div className="container mx-auto px-4">
           <Breadcrumb 
             items={[
               { label: 'ホーム', href: '/' },
@@ -57,16 +50,15 @@ export default async function ServiceDetailPage({
           />
           
           <section className="py-16">
-            <h2 className="text-3xl font-bold text-center mb-12">
-              {serviceTitle}の詳細
-            </h2>
-            <p className="text-lg mb-8 text-center">
-              {serviceDescription}
-            </p>
-            <ServiceFeatures />
+            <div className="w-full bg-[#F3F3F3] rounded-[50px] p-16">
+              <h2 className="text-3xl font-bold text-center mb-12">
+                {serviceTitle}の特徴
+              </h2>
+              <ServiceFeatures />
+            </div>
           </section>
 
-          <section className="py-16 bg-[#f3f3f3]">
+          <section className="py-16 bg-[#f3f3f3] rounded-[50px]">
             <h2 className="text-3xl font-bold text-center mb-12">
               {serviceTitle}の流れ
             </h2>
@@ -77,7 +69,6 @@ export default async function ServiceDetailPage({
               </Button>
             </div>
           </section>
-        </div>
 
         <FAQSection />
       </main>

--- a/nextjs-team-practice/app/services/components/contact-cta.tsx
+++ b/nextjs-team-practice/app/services/components/contact-cta.tsx
@@ -4,33 +4,35 @@ import { Mail, Phone, Clock } from 'lucide-react'
 export function ContactCTA() {
   return (
     <section className="py-16 bg-white">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-8">
-          <h2 className="text-4xl font-bold mb-4">
-            プロの塗装技術で、建物に新しい輝きを
-          </h2>
-          <p className="mb-2">まずはお気軽にご相談ください。</p>
-          <p>お客様に最適な施工をご提案いたします。</p>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
-          <div className="bg-[#005a64] text-white rounded-lg p-6">
-            <div className="flex items-center gap-2 mb-2">
-              <Clock className="h-5 w-5" />
-              <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Phone className="h-6 w-6" />
-              <span className="text-2xl font-bold">00-0000-0000</span>
-            </div>
+      <div className="w-full bg-[#F3F3F3] p-8">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-8">
+            <h2 className="text-4xl font-bold mb-4">
+              プロの塗装技術で、建物に新しい輝きを
+            </h2>
+            <p className="mb-2">まずはお気軽にご相談ください。</p>
+            <p>お客様に最適な施工をご提案いたします。</p>
           </div>
           
-          <Button 
-            className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6 flex items-center justify-center gap-2"
-          >
-            <Mail className="h-6 w-6" />
-            メールで相談 →
-          </Button>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
+            <div className="bg-[#005a64] text-white rounded-lg p-6">
+              <div className="flex items-center gap-2 mb-2">
+                <Clock className="h-5 w-5" />
+                <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Phone className="h-6 w-6" />
+                <span className="text-2xl font-bold">00-0000-0000</span>
+              </div>
+            </div>
+            
+            <Button 
+              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6 flex items-center justify-center gap-2"
+            >
+              <Mail className="h-6 w-6" />
+              メールで相談 →
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/nextjs-team-practice/app/services/components/cta-section.tsx
+++ b/nextjs-team-practice/app/services/components/cta-section.tsx
@@ -3,34 +3,36 @@ import { Mail, Phone, Clock } from 'lucide-react'
 
 export function CTASection() {
   return (
-    <section className="py-16 bg-white">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-8">
-          <h2 className="text-4xl font-bold mb-4">
-            プロの塗装技術で、建物に新しい輝きを
-          </h2>
-          <p className="mb-2">まずはお気軽にご相談ください。</p>
-          <p>お客様に最適な施工をご提案いたします。</p>
-        </div>
-        
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
-          <div className="bg-[#005a64] text-white rounded-lg p-6">
-            <div className="flex items-center gap-2 mb-2">
-              <Clock className="h-5 w-5" />
-              <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <Phone className="h-6 w-6" />
-              <span className="text-2xl font-bold">00-0000-0000</span>
-            </div>
+    <section className="py-5 bg-white">
+      <div className="w-full bg-[#F3F3F3] p-8">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-8">
+            <h2 className="text-4xl font-bold mb-4">
+              プロの塗装技術で、建物に新しい輝きを
+            </h2>
+            <p className="mb-2">まずはお気軽にご相談ください。</p>
+            <p>お客様に最適な施工をご提案いたします。</p>
           </div>
           
-          <Button 
-            className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6"
-          >
-            <Mail className="h-6 w-6 mr-2" />
-            メールで相談 →
-          </Button>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
+            <div className="bg-[#005a64] text-white rounded-lg p-6">
+              <div className="flex items-center gap-2 mb-2">
+                <Clock className="h-5 w-5" />
+                <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Phone className="h-6 w-6" />
+                <span className="text-2xl font-bold">00-0000-0000</span>
+              </div>
+            </div>
+            
+            <Button 
+              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6"
+            >
+              <Mail className="h-6 w-6 mr-2" />
+              メールで相談 →
+            </Button>
+          </div>
         </div>
       </div>
     </section>

--- a/nextjs-team-practice/app/services/components/faq-section.tsx
+++ b/nextjs-team-practice/app/services/components/faq-section.tsx
@@ -7,21 +7,17 @@ import {
 
 export function FAQSection() {
   return (
-    <section className="py-16 bg-white">
+    <section className="py-16 bg-[#F3F3F3] my-16 rounded-[50px]">
       <div className="container mx-auto px-4">
         <h2 className="text-3xl font-bold text-center mb-12">よくある質問</h2>
-        <div className="max-w-3xl mx-auto bg-[#f3f3f3] rounded-2xl p-8">
-          <Accordion type="single" collapsible>
-            <AccordionItem value="item-1">
-              <AccordionTrigger className="text-xl font-bold">
-                ○○について
-              </AccordionTrigger>
-              <AccordionContent>
-                ○○についてはテキストテキストテキストテキストテキストテキストテキスト
-                テキストテキストテキストテキストテキストテキストテキストテキストテキス
-              </AccordionContent>
-            </AccordionItem>
-          </Accordion>
+        <div className="max-w-3xl bg-[#f3f3f3] rounded-2xl p-8">
+          <div>
+            <h3 className="text-xl font-bold text-left mb-10">○○について</h3>
+            <p>
+              ○○についてはテキストテキストテキストテキストテキストテキストテキスト
+              テキストテキストテキストテキストテキストテキストテキストテキストテキス
+            </p>
+          </div>
         </div>
       </div>
     </section>

--- a/nextjs-team-practice/app/services/components/footer.tsx
+++ b/nextjs-team-practice/app/services/components/footer.tsx
@@ -24,11 +24,11 @@ const footerLinks = {
 
 export function Footer() {
   return (
-    <footer className="bg-white py-12 border-t">
+    <footer className="bg-[#F3F3F3] py-12 border-t">
       <div className="container mx-auto px-4">
         <div className="grid grid-cols-1 md:grid-cols-6 gap-8">
           <div className="md:col-span-2">
-            <h2 className="text-xl font-bold mb-4">MVP塗装</h2>
+            <h2 className="text-xl font-bold mb-4">MVP塗装1</h2>
             <p className="text-sm text-gray-600">
               確かな技術と丁寧な工事な姿勢で、
               <br />

--- a/nextjs-team-practice/app/services/components/service-features.tsx
+++ b/nextjs-team-practice/app/services/components/service-features.tsx
@@ -1,8 +1,8 @@
 export function ServiceFeatures() {
   return (
-    <div className="space-y-12">
+    <div className="space-y-12 mb-[20px]">
       <div className="max-w-3xl mx-auto">
-        <h3 className="text-xl mb-4">当社のサービスは、</h3>
+        <h3 className="text-xl">当社のサービスは、</h3>
         <p className="text-lg leading-relaxed">
           テキストテキストテキストテキストテキストテキストテキストテキストテキスト
           テキストテキストテキストテキストテキストテキストテキストテキストテキスト
@@ -10,24 +10,24 @@ export function ServiceFeatures() {
       </div>
 
       {/* 三角形レイアウト */}
-      <div className="relative max-w-[500px] h-[300px] mx-auto">
+      <div className="relative max-w-[500px] h-[500px] mx-auto">
         {/* 上部中央のテキスト */}
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[200px]">
-          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[300px] h-[200px]">
+          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg w-[300px] h-[200px] flex items-center justify-center h-full">
             <p className="text-lg font-bold">テキスト</p>
           </div>
         </div>
 
         {/* 下部左のテキスト */}
-        <div className="absolute bottom-0 left-0 w-[200px]">
-          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg">
+        <div className="absolute bottom-0 right-[305px] w-[300px] h-[200px]">
+          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg w-[300px] h-[200px] flex items-center justify-center h-full">
             <p className="text-lg font-bold">テキスト</p>
           </div>
         </div>
 
         {/* 下部右のテキスト */}
-        <div className="absolute bottom-0 right-0 w-[200px]">
-          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg">
+        <div className="absolute bottom-0 left-[305px] w-[300px] h-[200px]">
+          <div className="bg-[#22d6dd] rounded-lg p-4 text-center shadow-lg w-[300px] h-[200px] flex items-center justify-center h-full">
             <p className="text-lg font-bold">テキスト</p>
           </div>
         </div>

--- a/nextjs-team-practice/app/services/components/service-section.tsx
+++ b/nextjs-team-practice/app/services/components/service-section.tsx
@@ -17,45 +17,47 @@ interface ServiceSectionProps {
 
 export function ServiceSection({ title, mainCard, cards }: ServiceSectionProps) {
   return (
-    <section className="py-16">
-      <h2 className="text-3xl font-bold text-center mb-12">{title}</h2>
-      
-      {/* Main Card */}
-      <Card className="mb-8 overflow-hidden">
-        <div className="flex flex-col md:flex-row">
-          <div className="p-8 md:w-1/2">
-            <h3 className="text-[32px] font-bold mb-4">{mainCard.title}</h3>
-            <p className="text-sm mb-6">{mainCard.description}</p>
-            <Link href={mainCard.link} passHref>
-              <Button variant="outline" className="border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
-                詳細を見る→
-              </Button>
-            </Link>
-          </div>
-          <div className="md:w-1/2 bg-[#404040] aspect-video flex items-center justify-center text-white">
-            画像1
-          </div>
-        </div>
-      </Card>
-
-      {/* Sub Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        {cards.map((card, index) => (
-          <Card key={index} className="overflow-hidden">
-            <div className="bg-[#404040] aspect-video flex items-center justify-center text-white">
-              画像1
-            </div>
-            <div className="p-6">
-              <h3 className="text-[32px] font-bold mb-4">{card.title}</h3>
-              <p className="text-sm mb-4">{card.description}</p>
-              <Link href={card.link} passHref>
-                <Button variant="outline" className="w-full border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
+    <section className="py-5">
+      <div className="w-full bg-[#F3F3F3] rounded-[50px] p-16">
+        <h2 className="text-3xl font-bold text-center mb-12">{title}</h2>
+        
+        {/* Main Card */}
+        <Card className="mb-8 overflow-hidden">
+          <div className="flex flex-col md:flex-row">
+            <div className="p-8 md:w-1/2 bg-[#FFFFFF]">
+              <h3 className="text-[32px] font-bold mb-4">{mainCard.title}</h3>
+              <p className="text-sm mb-6 py-5">{mainCard.description}</p>
+              <Link href={mainCard.link} passHref>
+                <Button variant="outline" className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
                   詳細を見る→
                 </Button>
               </Link>
             </div>
-          </Card>
-        ))}
+            <div className="md:w-1/2 bg-[#404040] aspect-video flex items-center justify-center text-white">
+              画像1
+            </div>
+          </div>
+        </Card>
+
+        {/* Sub Cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {cards.map((card, index) => (
+            <Card key={index} className="overflow-hidden">
+              <div className="bg-[#404040] aspect-video flex items-center justify-center text-white">
+                画像1
+              </div>
+              <div className="p-6 bg-[#FFFFFF]">
+                <h3 className="text-[32px] font-bold mb-4">{card.title}</h3>
+                <p className="text-sm mb-4 py-5">{card.description}</p>
+                <Link href={card.link} passHref>
+                  <Button variant="outline" className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
+                    詳細を見る→
+                  </Button>
+                </Link>
+              </div>
+            </Card>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/nextjs-team-practice/app/services/components/special-painting.tsx
+++ b/nextjs-team-practice/app/services/components/special-painting.tsx
@@ -25,48 +25,50 @@ const specialPaintingCards = [
 
 export function SpecialPainting() {
   return (
-    <section className="py-16">
-      <h2 className="text-3xl font-bold text-center mb-12">特殊塗装</h2>
-      
-      {/* メインカード */}
-      <Card className="mb-8 overflow-hidden shadow-lg">
-        <div className="flex flex-col md:flex-row">
-          <div className="p-8 md:w-1/2">
-            <h3 className="text-[32px] font-bold mb-4">タイトル：32px-Bold</h3>
-            <p className="text-sm mb-6">
-              テキストテキストテキストテキストテキストテキスト
-              テキストテキストテキストテキストテキストテキスト
-            </p>
-            <Link href="/services/special-painting" passHref>
-              <Button variant="outline" className="border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
-                詳細を見る→
-              </Button>
-            </Link>
-          </div>
-          <div className="md:w-1/2 bg-[#404040] aspect-video flex items-center justify-center text-white">
-            画像1
-          </div>
-        </div>
-      </Card>
-
-      {/* サブカード */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-        {specialPaintingCards.map((card, index) => (
-          <Card key={index} className="overflow-hidden shadow-lg">
-            <div className="bg-[#404040] aspect-video flex items-center justify-center text-white">
-              画像1
-            </div>
-            <div className="p-6">
-              <h3 className="text-[32px] font-bold mb-4">{card.title}</h3>
-              <p className="text-sm mb-4">{card.description}</p>
-              <Link href={card.link} passHref>
-                <Button variant="outline" className="w-full border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
+    <section className="py-5">
+      <div className="w-full bg-[#F3F3F3] rounded-[50px] p-16">
+        <h2 className="text-3xl font-bold text-center mb-12">特殊塗装</h2>
+        
+        {/* メインカード */}
+        <Card className="mb-8 overflow-hidden shadow-lg">
+          <div className="flex flex-col md:flex-row">
+            <div className="p-8 md:w-1/2 bg-[#FFFFFF]">
+              <h3 className="text-[32px] font-bold mb-4">タイトル：32px-Bold</h3>
+              <p className="text-sm mb-6">
+                テキストテキストテキストテキストテキストテキスト
+                テキストテキストテキストテキストテキストテキスト
+              </p>
+              <Link href="/services/special-painting" passHref>
+                <Button variant="outline" className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
                   詳細を見る→
                 </Button>
               </Link>
             </div>
-          </Card>
-        ))}
+            <div className="md:w-1/2 bg-[#404040] aspect-video flex items-center justify-center text-white">
+              画像1
+            </div>
+          </div>
+        </Card>
+
+        {/* サブカード */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {specialPaintingCards.map((card, index) => (
+            <Card key={index} className="overflow-hidden shadow-lg">
+              <div className="bg-[#404040] aspect-video flex items-center justify-center text-white">
+                画像1
+              </div>
+              <div className="p-6 bg-[#FFFFFF]">
+                <h3 className="text-[32px] font-bold mb-4">{card.title}</h3>
+                <p className="text-sm mb-4 py-5">{card.description}</p>
+                <Link href="/services/special-painting" passHref>
+                  <Button variant="outline" className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300">
+                    詳細を見る→
+                  </Button>
+                </Link>
+              </div>
+            </Card>
+          ))}
+        </div>
       </div>
     </section>
   )

--- a/nextjs-team-practice/app/services/page.tsx
+++ b/nextjs-team-practice/app/services/page.tsx
@@ -54,7 +54,7 @@ export default function ServicesPage() {
       <Header />
       <ServiceHero />
       <main className="bg-[#ffffff]">
-          <Breadcrumb 
+        <div className="container mx-auto px-4">          <Breadcrumb 
             items={[
               { label: 'ホーム', href: '/' },
               { label: 'サービス', href: '/services' }
@@ -81,7 +81,8 @@ export default function ServicesPage() {
             }}
           />
           <SpecialPainting />
-          <CTASection />
+        </div>
+        <CTASection />
       </main>
       <Footer />
     </div>

--- a/nextjs-team-practice/app/services/page.tsx
+++ b/nextjs-team-practice/app/services/page.tsx
@@ -53,8 +53,7 @@ export default function ServicesPage() {
     <div className="min-h-screen">
       <Header />
       <ServiceHero />
-      <main className="bg-[#f3f3f3]">
-        <div className="container mx-auto px-4">
+      <main className="bg-[#ffffff]">
           <Breadcrumb 
             items={[
               { label: 'ホーム', href: '/' },
@@ -83,7 +82,6 @@ export default function ServicesPage() {
           />
           <SpecialPainting />
           <CTASection />
-        </div>
       </main>
       <Footer />
     </div>

--- a/nextjs-team-practice/app/works/components/works-list.tsx
+++ b/nextjs-team-practice/app/works/components/works-list.tsx
@@ -70,7 +70,7 @@ export function WorksList() {
                 <Link href={`/works/${work.id}`} className="block">
                   <Button 
                     variant="outline" 
-                    className="w-full border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
+                    className="w-[45%] border-[#000000] shadow-md hover:bg-[#000000] hover:text-white transition-colors duration-300"
                   >
                     詳細を見る→
                   </Button>


### PR DESCRIPTION
## 変更内容
・サービスページ・サービス詳細ページ
外壁塗装セクションの背景が消えてる：F3F3F3（グレー）の背景を追加
外壁塗装セクションの内容のpaddingがおかしい：paddingを増加
屋根塗装セクションの背景が消えてる：F3F3F3（グレー）の背景を追加
屋根塗装セクションの内容のpaddingがおかしい：paddingを増加
最新の施工例セクションの背景が消えてる：F3F3F3（グレー）の背景を追加
詳細ページ○○塗装の詳細セクションの背景が消えてる：F3F3F3（グレー）の背景を追加
詳細ページ○○塗装の詳細セクションのレイアウトが全体的におかしい：Figmaレイアウトに寄せた
詳細ページ○○塗装のよくある質問セクションのレイアウトが全体的におかしい：Figmaレイアウトに寄せた

・共通コンポーネント
フッター：背景色がFigmaと異なる：F3F3F3（グレー）の背景を追加
詳細を見る→のボタンのサイズが大きく異なる：親要素の45%に修正
STEP1/2/3の枠が小さい：枠を拡大

## 確認方法
1. ホームぺージの表示
2. サービスページの表示
3. サービス詳細画面の表示

## スクリーンショット
画面全体のため割愛

## 補足事項
特になし