### PR TITLE
Future/common components cta header：ヘッダーUIの改善とCTAセクションの共通コンポーネント化

### DIFF
--- a/nextjs-team-practice/app/components/cta-section.tsx
+++ b/nextjs-team-practice/app/components/cta-section.tsx
@@ -1,43 +1,4 @@
-import { Button } from "@/components/ui/button"
-import { Mail, Phone, Clock } from 'lucide-react'
+import { CTASection } from "./shared/cta-section"
 
-// コメント
-export function CTASection() {
-  return (
-    <section className="py-16">
-      <div className="w-full bg-[#F3F3F3] p-16">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-12">
-            <h2 className="text-[64px] font-bold mb-4">
-              プロの塗装技術で、建物に新しい輝きを
-            </h2>
-            <p className="text-[18px] font-bold mb-2">まずはお気軽にご相談ください。</p>
-            <p className="text-[18px] font-bold">お客様に最適な施工をご提案いたします。</p>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
-            <div className="bg-[#005a64] text-white rounded-lg p-8 flex flex-col justify-center ">
-              <div className="flex items-center gap-4 mb-4 whitespace-nowrap justify-center">
-                <Clock className="h-6 w-6 flex-shrink-0" />
-                <span className="text-[16px] font-bold">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
-              </div>
-              <div className="flex items-center gap-4 whitespace-nowrap justify-center">
-                <Phone className="h-6 w-6 flex-shrink-0" />
-                <span className="text-[48px] font-bold leading-none">00-0000-0000</span>
-              </div>
-            </div>
-            
-            <Button 
-              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-full p-8 flex items-center justify-center gap-4 rounded-lg [&_svg]:w-12 [&_svg]:h-12"
-            >
-              <Mail className="flex-shrink-0" />
-              <span className="text-[48px] font-bold leading-none">メールで相談</span>
-              <span className="text-[48px] leading-none">→</span>
-            </Button>
-          </div>
-        </div>
-      </div>
-    </section>
-  )
-}
+export { CTASection }
 

--- a/nextjs-team-practice/app/components/shared/cta-section.tsx
+++ b/nextjs-team-practice/app/components/shared/cta-section.tsx
@@ -1,0 +1,41 @@
+import { Button } from "@/components/ui/button"
+import { Mail, Phone, Clock } from 'lucide-react'
+
+export function CTASection() {
+  return (
+    <section className="py-16 bg-white">
+      <div className="w-full bg-[#F3F3F3] p-16">
+        <div className="container mx-auto px-4">
+          <div className="text-center mb-12">
+            <h2 className="text-[64px] font-bold mb-4">
+              プロの塗装技術で、建物に新しい輝きを
+            </h2>
+            <p className="text-[18px] font-bold mb-2">まずはお気軽にご相談ください。</p>
+            <p className="text-[18px] font-bold">お客様に最適な施工をご提案いたします。</p>
+          </div>
+          
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+            <div className="bg-[#005a64] text-white rounded-lg p-8 flex flex-col justify-center">
+              <div className="flex items-center gap-4 mb-4 whitespace-nowrap justify-center">
+                <Clock className="h-6 w-6 flex-shrink-0" />
+                <span className="text-[16px] font-bold">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
+              </div>
+              <div className="flex items-center gap-4 whitespace-nowrap justify-center">
+                <Phone className="h-6 w-6 flex-shrink-0" />
+                <span className="text-[48px] font-bold leading-none">00-0000-0000</span>
+              </div>
+            </div>
+            
+            <Button 
+              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-full p-8 flex items-center justify-center gap-4 rounded-lg [&_svg]:w-12 [&_svg]:h-12"
+            >
+              <Mail className="flex-shrink-0" />
+              <span className="text-[48px] font-bold leading-none">メールで相談</span>
+              <span className="text-[48px] leading-none">→</span>
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+} 

--- a/nextjs-team-practice/app/components/shared/header.tsx
+++ b/nextjs-team-practice/app/components/shared/header.tsx
@@ -1,46 +1,87 @@
+'use client'
+
 import Link from 'next/link'
+import { usePathname } from 'next/navigation'
 
 export function Header() {
+  const pathname = usePathname()
+
   return (
     <header>
       <div className="bg-[#f3f3f3] py-1">
-        <div className="container mx-auto px-4 flex justify-end gap-4 text-sm">
-          <span>⏰ 営業時間: 9:00-18:00（土日祝除く）</span>
-          <a href="tel:03-XXXX-XXXX" className="hover:underline">📞 03-XXXX-XXXX</a>
+        <div className="container mx-auto px-4 flex justify-end gap-6 text-sm">
+          <span className="flex items-center gap-1">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            営業時間: 9:00-18:00（土日祝除く）
+          </span>
+          <a href="tel:03-XXXX-XXXX" className="flex items-center gap-1">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+            </svg>
+            03-XXXX-XXXX
+          </a>
         </div>
       </div>
       <div className="border-b">
         <div className="container mx-auto px-4 flex items-center justify-between h-16">
-          <Link href="/" className="text-xl font-bold">
+          <Link 
+            href="/" 
+            className="text-xl font-bold text-gray-900 hover:text-black transition-colors"
+          >
             MVP塗装
           </Link>
           <nav>
-            <ul className="flex gap-6">
-              <li>
-                <Link href="/" className="hover:text-gray-600 transition-colors">
-                  ホーム
-                </Link>
-              </li>
-              <li>
-                <Link href="/services" className="hover:text-gray-600 transition-colors">
-                  サービス
-                </Link>
-              </li>
-              <li>
-                <Link href="/works" className="hover:text-gray-600 transition-colors">
-                  施工事例
-                </Link>
-              </li>
-              <li>
-                <Link href="/company" className="hover:text-gray-600 transition-colors">
-                  会社案内
-                </Link>
-              </li>
-              <li>
-                <Link href="/contact" className="hover:text-gray-600 transition-colors">
-                  お問い合わせ
-                </Link>
-              </li>
+            <ul className="flex gap-8">
+              {[
+                { href: '/', label: 'ホーム', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
+                { href: '/services', label: 'サービス', icon: 'M21 13.255A23.931 23.931 0 0112 15c-3.183 0-6.22-.62-9-1.745M16 6V4a2 2 0 00-2-2h-4a2 2 0 00-2 2v2m4 6h.01M5 20h14a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z' },
+                { href: '/works', label: '施工事例', icon: 'M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z' },
+                { href: '/company', label: '会社案内', icon: 'M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4' },
+                { href: '/contact', label: 'お問い合わせ', icon: 'M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z' },
+              ].map(({ href, label, icon }) => (
+                <li key={href} className="relative">
+                  <Link
+                    href={href}
+                    className={`
+                      flex items-center gap-1.5
+                      py-2 px-1
+                      transition-all
+                      duration-300
+                      hover:text-gray-900 hover:font-medium
+                      ${pathname === href ? 'text-gray-900 font-medium' : 'text-gray-600'}
+                      group
+                    `}
+                  >
+                    <svg 
+                      className="w-4 h-4" 
+                      fill="none" 
+                      viewBox="0 0 24 24" 
+                      stroke="currentColor"
+                    >
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={icon} />
+                    </svg>
+                    {label}
+                    <span
+                      className={`
+                        absolute
+                        -bottom-[1px]
+                        left-0
+                        w-full
+                        h-0.5
+                        bg-gray-900
+                        transform
+                        origin-left
+                        transition-all
+                        duration-300
+                        ${pathname === href ? 'scale-x-100 opacity-100' : 'scale-x-0 opacity-0'}
+                        group-hover:scale-x-100 group-hover:opacity-100
+                      `}
+                    />
+                  </Link>
+                </li>
+              ))}
             </ul>
           </nav>
         </div>

--- a/nextjs-team-practice/app/services/components/contact-cta.tsx
+++ b/nextjs-team-practice/app/services/components/contact-cta.tsx
@@ -1,41 +1,6 @@
-import { Button } from "@/components/ui/button"
-import { Mail, Phone, Clock } from 'lucide-react'
+import { CTASection } from "../../components/shared/cta-section"
 
 export function ContactCTA() {
-  return (
-    <section className="py-16 bg-white">
-      <div className="w-full bg-[#F3F3F3] p-8">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-4xl font-bold mb-4">
-              プロの塗装技術で、建物に新しい輝きを
-            </h2>
-            <p className="mb-2">まずはお気軽にご相談ください。</p>
-            <p>お客様に最適な施工をご提案いたします。</p>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
-            <div className="bg-[#005a64] text-white rounded-lg p-6">
-              <div className="flex items-center gap-2 mb-2">
-                <Clock className="h-5 w-5" />
-                <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Phone className="h-6 w-6" />
-                <span className="text-2xl font-bold">00-0000-0000</span>
-              </div>
-            </div>
-            
-            <Button 
-              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6 flex items-center justify-center gap-2"
-            >
-              <Mail className="h-6 w-6" />
-              メールで相談 →
-            </Button>
-          </div>
-        </div>
-      </div>
-    </section>
-  )
+  return <CTASection />
 }
 

--- a/nextjs-team-practice/app/services/components/cta-section.tsx
+++ b/nextjs-team-practice/app/services/components/cta-section.tsx
@@ -1,41 +1,4 @@
-import { Button } from "@/components/ui/button"
-import { Mail, Phone, Clock } from 'lucide-react'
+import { CTASection } from "../../components/shared/cta-section"
 
-export function CTASection() {
-  return (
-    <section className="py-5 bg-white">
-      <div className="w-full bg-[#F3F3F3] p-8">
-        <div className="container mx-auto px-4">
-          <div className="text-center mb-8">
-            <h2 className="text-4xl font-bold mb-4">
-              プロの塗装技術で、建物に新しい輝きを
-            </h2>
-            <p className="mb-2">まずはお気軽にご相談ください。</p>
-            <p>お客様に最適な施工をご提案いたします。</p>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-2xl mx-auto">
-            <div className="bg-[#005a64] text-white rounded-lg p-6">
-              <div className="flex items-center gap-2 mb-2">
-                <Clock className="h-5 w-5" />
-                <span className="text-sm">営業時間 月〜土 08:00〜19:00 / 日曜も対応可能</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <Phone className="h-6 w-6" />
-                <span className="text-2xl font-bold">00-0000-0000</span>
-              </div>
-            </div>
-            
-            <Button 
-              className="bg-[#005a64] hover:bg-[#005a64]/90 text-white h-auto py-6"
-            >
-              <Mail className="h-6 w-6 mr-2" />
-              メールで相談 →
-            </Button>
-          </div>
-        </div>
-      </div>
-    </section>
-  )
-}
+export { CTASection }
 


### PR DESCRIPTION
## 変更概要
### ヘッダーコンポーネントの改善
- メニュー項目にアイコンを追加し、ナビゲーションの視認性を向上
- ホバー時のアンダーラインアニメーションを実装
- アクティブなメニュー項目のスタイリングを改善
- 営業時間と電話番号を上部に配置し、アクセシビリティを向上

### CTAセクションの最適化
- 重複していたCTAセクションのコードを共通コンポーネントとして統合
- `shared/`ディレクトリに移動し、コンポーネントの再利用性を向上
- 各ページで共通コンポーネントを使用するように変更

## 影響範囲
- `header.tsx`
- `cta-section.tsx`関連ファイル
- `page.tsx`

## テスト項目
- [ ] ヘッダーのナビゲーションメニューが正しく表示される
- [ ] アイコンとホバーエフェクトが期待通りに動作する
- [ ] CTAセクションが全ページで正しく表示される
- [ ] レスポンシブデザインが崩れていない

## スクリーンショット
### 旧バージョン
1. サービスページのCTA
![image](https://github.com/user-attachments/assets/f4842020-1d3b-40f1-bcf8-5c181142e420)

2. 施工管理ページのCTA
![image](https://github.com/user-attachments/assets/601e6942-c353-42db-8880-c16763285646)

3. 会社案内CTA
![image](https://github.com/user-attachments/assets/605d5fd2-6d13-4bff-910c-5081a8005ab3)

4. ヘッダー
![image](https://github.com/user-attachments/assets/f99c07d1-bd8c-4322-be47-f9ab7a591a2b)


### 新バージョン
1. サービスページのCTA
![image](https://github.com/user-attachments/assets/8e1bad0d-68f2-40a3-8305-d692eb0d5807)

2. 施工管理ページのCTA
![image](https://github.com/user-attachments/assets/be65a18b-06e8-4484-8b20-0a36a625d57a)

3. 会社案内CTA
![image](https://github.com/user-attachments/assets/ffc01e7c-b043-4792-bf82-b5c5c3df1ed5)

4. ヘッダー
![image](https://github.com/user-attachments/assets/7eb3ad39-d821-44bf-8da4-8a32c2f17129)





