### PR TITLE
Fix/footer site map：フッターのUIを改善

### DIFF
--- a/nextjs-team-practice/app/components/shared/footer.tsx
+++ b/nextjs-team-practice/app/components/shared/footer.tsx
@@ -1,49 +1,82 @@
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
+import { ArrowRight, Phone, Mail, MapPin } from 'lucide-react'
 
 const footerLinks = {
-  ホーム: [
-    { title: "サービス概要", href: "#" },
-    { title: "よくある質問", href: "#" }
-  ],
-  サービス: [
-    { title: "サービス一覧", href: "/services" },
-    { title: "料金プラン", href: "#" }
-  ],
-  施工事例: [
-    { title: "施工事例一覧", href: "/works" },
-    { title: "料金プラン", href: "#" }
-  ],
-  会社案内: [
-    { title: "会社概要", href: "/company" },
-    { title: "事業内容", href: "#" },
-    { title: "アクセス情報", href: "#" }
-  ],
-  お問い合わせ: []
+  ホーム: {
+    href: "/",
+    links: [
+      { title: "サービス概要", href: "#services" },
+      { title: "当社の特徴", href: "#features" },
+      { title: "施工の流れ", href: "#process" }
+    ]
+  },
+  サービス: {
+    href: "/services",
+    links: [
+      { title: "外壁塗装", href: "/services/exterior-wall-painting" },
+      { title: "屋根塗装", href: "/services/roof-painting" },
+      { title: "特殊塗装", href: "/services/special-painting" }
+    ]
+  },
+  施工事例: {
+    href: "/works",
+    links: [
+      { title: "施工事例一覧", href: "/works" }
+    ]
+  },
+  会社案内: {
+    href: "/company",
+    links: [
+      { title: "企業理念", href: "/company#philosophy" },
+      { title: "会社概要", href: "/company#overview" },
+      { title: "沿革", href: "/company#history" }
+    ]
+  },
+  お問い合わせ: {
+    href: "/contact",
+    links: []
+  }
 }
 
 export function Footer() {
   return (
-    <footer className="bg-[#F3F3F3] py-12 border-t">
-      <div className="container mx-auto px-4">
-        <div className="grid grid-cols-1 md:grid-cols-6 gap-8">
-          <div className="md:col-span-2">
-            <h2 className="text-xl font-bold mb-4">MVP塗装</h2>
-            <p className="text-sm text-gray-600">
+    <footer className="bg-[#F3F3F3]">
+      {/* メインフッター */}
+      <div className="container mx-auto px-4 py-16">
+        <div className="grid grid-cols-1 md:grid-cols-6 gap-12">
+          {/* 左カラム：会社情報 */}
+          <div className="md:col-span-2 space-y-6">
+            <Link href="/" className="inline-block group">
+              <h2 className="text-2xl font-bold text-gray-900 group-hover:text-[#005a64] transition-colors">
+                MVP塗装
+              </h2>
+            </Link>
+            <p className="text-base text-gray-600 leading-relaxed">
               確かな技術と丁寧な工事な姿勢で、
               <br />
               あなたの大切な空間を新たな姿にします
             </p>
           </div>
-          <div className="md:col-span-4 grid grid-cols-2 md:grid-cols-5 gap-8">
-            {Object.entries(footerLinks).map(([category, links]) => (
-              <div key={category}>
-                <h3 className="font-bold mb-4">{category}</h3>
+
+          {/* 右カラム：ナビゲーション */}
+          <div className="md:col-span-4 grid grid-cols-2 md:grid-cols-5 gap-2  md:gap-4">
+            {Object.entries(footerLinks).map(([category, { href, links }]) => (
+              <div key={category} className="space-y-4">
+                <Link 
+                  href={href}
+                  className="inline-block text-lg font-bold text-gray-900 hover:text-[#005a64] transition-colors"
+                >
+                  {category}
+                </Link>
                 {links.length > 0 && (
-                  <ul className="space-y-2">
+                  <ul className="space-y-3">
                     {links.map((link) => (
                       <li key={link.title}>
-                        <Link href={link.href} className="text-sm text-gray-600 hover:text-gray-900">
+                        <Link 
+                          href={link.href} 
+                          className="text-gray-600 hover:text-[#005a64] transition-colors block text-sm"
+                        >
                           {link.title}
                         </Link>
                       </li>
@@ -51,18 +84,35 @@ export function Footer() {
                   </ul>
                 )}
                 {category === 'お問い合わせ' && (
-                  <Link href="/contact">
-                    <Button className="bg-[#005a64] text-white hover:bg-[#005a64]/90">
-                      お問い合わせ →
-                    </Button>
-                  </Link>
+                  <div className="pt-0">
+                    <Link href="/contact">
+                      <Button className="bg-[#005a64] text-white hover:bg-[#005a64]/90 shadow-md hover:shadow-lg transition-all duration-300 w-full h-8 px-2">
+                        <span className="text-[10px]">見積もりを依頼</span>
+                        <ArrowRight className="h-2.5 w-2.5 ml-1" />
+                      </Button>
+                    </Link>
+                  </div>
                 )}
               </div>
             ))}
           </div>
         </div>
-        <div className="mt-8 pt-8 border-t text-center text-sm text-gray-600">
-          © 2024 MVP塗装
+
+        {/* コピーライト */}
+        <div className="mt-16 pt-8 border-t border-gray-200">
+          <div className="flex flex-col md:flex-row justify-between items-center gap-4">
+            <p className="text-sm text-gray-600">
+              © 2024 MVP塗装 All Rights Reserved.
+            </p>
+            <div className="flex gap-6 text-sm">
+              <Link href="/privacy-policy" className="text-gray-600 hover:text-[#005a64] transition-colors">
+                プライバシーポリシー
+              </Link>
+              <Link href="/terms" className="text-gray-600 hover:text-[#005a64] transition-colors">
+                利用規約
+              </Link>
+            </div>
+          </div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
# refactor(footer): フッターのUIを改善
## 変更内容
- フッターのナビゲーション構造を最適化
- 見積もり依頼ボタンのデザインを調整
  - ボタンサイズとテキストを縮小
  - 配置を最適化
- グリッドレイアウトの間隔を調整
- リンク構造をサイトマップに合わせて更新

## old
<img width="1440" alt="スクリーンショット 2025-01-22 22 56 22" src="https://github.com/user-attachments/assets/e8898885-9e1f-4ce1-9160-8dea41148fbb" />

## new
<img width="1440" alt="スクリーンショット 2025-01-22 22 56 06" src="https://github.com/user-attachments/assets/6a090dcc-f9e3-46be-a8e3-df592e5d7d86" />



## 関連Issues
https://github.com/TomoyaSekiWk315/NextJsTeamPractice/issues/19